### PR TITLE
abnfgen ported to rudix

### DIFF
--- a/Ports/abnfgen/Description
+++ b/Ports/abnfgen/Description
@@ -1,0 +1,7 @@
+Given an Augmented Backus-Naur form (ABNF) grammar (Wikipedia, RFC 4234), abnfgen quickly generates lots of random documents that match that grammar.
+
+  * Site: http://www.quut.com/abnfgen/
+  * License: while copyrighted, free for any use
+
+Release Notes:
+  * Ported to rudix

--- a/Ports/abnfgen/Makefile
+++ b/Ports/abnfgen/Makefile
@@ -1,0 +1,17 @@
+# Package Maintainer: Qichang Liang
+# email: kcleung@cs.otago.ac.nz
+
+include ../../Library/Config.mk
+include ../../Library/Rudix.mk
+include ../../Library/GNUFormula.mk
+
+Title=		abnfgen
+Name=		abnfgen
+Version=	0.16
+Revision=	0
+URL=		http://www.quut.com/abnfgen/
+Source=		$(Name)-$(Version).tar.gz
+
+ReadMeFile=	$(SourceDir)/README
+LicenseFile=	$(SourceDir)/COPYING
+


### PR DESCRIPTION
abnfgen is a grammar test case generator, and is ported to rudix.

It has a license of:

"Copyrighted, but free for any use"

so would this license be compartibable with BSD or GPL license?
