### PR TITLE
qemu: update to QEMU 1.3.1

### DIFF
--- a/Ports/qemu/Makefile
+++ b/Ports/qemu/Makefile
@@ -19,6 +19,10 @@ ReadMeFile=	$(SourceDir)/qemu-doc.html
 LicenseFile=	$(SourceDir)/LICENSE
 ConfigureExtra += --with-system-pixman
 
+# i686-apple-darwin11-llvm-gcc-4.2 global register variable and inline asm
+# is not very reliable, so it's better to use clang instead
+EnvExtra += CC=clang
+
 #ConfigureExtra += --enable-cocoa
 #ConfigureExtra += --disable-bsd-user
 #ConfigureExtra += --disable-darwin-user


### PR DESCRIPTION
- Add pixman dependency (using --with-system-pixman instead of the
  pixman source tree bundled with QEMU)
- Add libintl dependency

Signed-off-by: Eduardo Habkost ehabkost@raisama.net

I expected the binaries built using llvm-gcc to be completely broken, like the last time I tested it, but they are surprisingly working (I am booting an Ubuntu disk image right now). But I plan to send a pull request changing it to use clang, because inline asm support in i686-apple-darwin11-llvm-gcc-4.2 is not very reliable.
