### PR TITLE
slang: Don't build as Universal Binary (see issue #23).

### DIFF
--- a/Ports/slang/Description
+++ b/Ports/slang/Description
@@ -5,7 +5,8 @@ S-Lang is a multi-platform programmer's library designed to allow a developer to
 
 Release Notes:
 
-* Adopted S-Lang version 2.2.4
+* S-Lang version 2.2.4
+* No longer built as Universal [https://github.com/rudix-mac/rudix/issues/23]
 
 Installation and usage:
 

--- a/Ports/slang/Makefile
+++ b/Ports/slang/Makefile
@@ -1,9 +1,12 @@
 include ../../Library/GNU.mk
+ifeq ($(OSXVersion),10.6)
+RUDIX_UNIVERSAL=no
+endif
 
 Title=		S-Lang
 Name=		slang
 Version=	2.2.4
-Revision=	1
+Revision=	2
 URL=		ftp://space.mit.edu/pub/davis/slang/v2.2
 Source=		$(Name)-$(Version).tar.gz
 


### PR DESCRIPTION
Don't build S-lang as Universal Binary on Snow Leopard, due:
S-Lang Library not built properly.  Fix SIZEOF_\* in config.h and recompile

Signed-off-by: Rudá Moura ruda.moura@gmail.com
