### PR TITLE
Update mtr for Mavericks compatibility

### DIFF
--- a/Ports/mtr/Makefile
+++ b/Ports/mtr/Makefile
@@ -4,9 +4,9 @@ Title=		MTR
 Name=		mtr
 Version=	0.85
 Revision=	0
-Site=		http://www.bitwizard.nl/mtr/
-URL=		https://github.com/traviscross/mtr/archive
-Source=		v$(Version).tar.gz
+Site=		https://github.com/traviscross/mtr
+URL=		ftp://www.bitwizard.nl/mtr/
+Source=		mtr-$(Version).tar.gz
 License=	GPL
 
 ConfigureExtra += --without-gtk

--- a/Ports/mtr/patches/mavericks.patch
+++ b/Ports/mtr/patches/mavericks.patch
@@ -1,0 +1,11 @@
+--- asn.c.orig  2014-03-24 07:41:19.000000000 +1100
++++ asn.c 2014-03-24 07:41:26.000000000 +1100
+@@ -21,7 +21,7 @@
+ #include <stdlib.h>
+ #include <sys/types.h>
+
+-#ifndef __APPLE__
++#ifdef __APPLE__
+ #define BIND_8_COMPAT
+ #endif
+ #include <arpa/nameser.h>


### PR DESCRIPTION
- Switched Site and URL values in the makefile; github might effectively
  be the homepage now, but it isn't where the released version source is
  distributed from.
- Updated Source pattern accordingly, to match the release .tgz from the
  website
- Added a small patch which enables the 0.85 release to build on
  mavericks.
