### PR TITLE
dependency for newers matplotplib installations (1.1.1 > 1.3.1) without requiring xquartz

### DIFF
--- a/Ports/freetype/Description
+++ b/Ports/freetype/Description
@@ -1,0 +1,7 @@
+FreeType is a freely available software library to render fonts.
+
+  * Site: http://www.freetype.org/
+  * License: FTP/GPL Version 2
+
+Release Notes:
+  * Freetype 2.5.2

--- a/Ports/freetype/Makefile
+++ b/Ports/freetype/Makefile
@@ -1,0 +1,9 @@
+include ../../Library/GNU.mk
+
+Title=		Freetype
+Name=		freetype
+Version=	2.5.2
+Revision=	0
+URL=		http://download.savannah.gnu.org/releases/freetype/
+Source=		$(Name)-$(Version).tar.gz
+LicenseFile=	$(SourceDir)/docs/LICENSE.txt

--- a/Ports/freetype/scripts/postinstall
+++ b/Ports/freetype/scripts/postinstall
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+[ ! -d /usr/local/include/freetype ] && ln -s /usr/local/include/freetype2/ /usr/local/include/freetype
+[ ! -f /usr/local/include/ft2build.h ] && ln -s /usr/local/include/freetype2/ft2build.h /usr/local/include/ft2build.h
+
+exit 0


### PR DESCRIPTION
Currently OSX Mavericks comes with Matplotlib 1.1.1 and in order to pip install -U it to 1.3.1 you'll need Freetype. You can either install XQuartz (65M) to provide it or now install it directly from Rudix.

Because of Apple's cc (Apple LLVM version 5.1) messing with the compile flags, you'll need to export CFLAGS=-Qunused-arguments and CPPFLAGS=-Qunused-arguments before testing this .pkg to build Matplotlib.

Worked like a charm here.
