### PR TITLE
First stab at adding ngrep

### DIFF
--- a/Ports/ngrep/Makefile
+++ b/Ports/ngrep/Makefile
@@ -1,0 +1,24 @@
+include ../../Library/GNU.mk
+
+Description=    ngrep provides a grep-like interface to the network layer
+Title=		ngrep
+Name=		ngrep
+Version=	1.45
+Revision=	0
+Site=		http://ngrep.sourceforge.net
+URL=		http://kent.dl.sourceforge.net/project/ngrep/ngrep/$(Version)/
+Source=	        ngrep-$(Version).tar.bz2
+License=	BSD like
+ReadMeFile=     $(SourceDir)/doc/README.txt
+LicenseFile=    $(SourceDir)/LICENSE.txt
+
+ConfigureExtra += --with-pcap-includes=/usr/include/pcap
+LdFlags += -lresolv
+
+define prep_post_hook
+rm -rf $(SourceDir)/autom4te.cache $(SourceDir)/{.deps,Makefile}
+endef
+
+define test_inner_hook
+$(SBinDir)/ngrep -V | grep V$(Version)
+endef


### PR DESCRIPTION
I'm not sure what to call the licence; it seems to be the BSD licence
with a few clauses about attribution added (which I _think_ we're
complying with)

This has only been tested on Yosemite.

I'm guessing this will need some tweaking (the name of the license at least) before it can land.
