### PR TITLE
Update bash-completion to 2.7

### DIFF
--- a/Ports/bash-completion/Makefile
+++ b/Ports/bash-completion/Makefile
@@ -2,10 +2,11 @@ include ../../Library/GNU.mk
 
 Title=		Bash Completion
 Name=		bash-completion
-Version=	2.5
-Site=		http://bash-completion.alioth.debian.org
-Source=		http://bash-completion.alioth.debian.org/files/$(Name)-$(Version).tar.bz2
+Version=	2.7
+Site=       https://github.com/scop/bash-completion/
+Source=     https://github.com/scop/$(Name)/releases/download/$(Version)/$(Name)-$(Version).tar.xz
 License=	GPL
+ReadMeFile=	$(SourceDir)/README.md
 
 define install_post_hook
 mv $(InstallDir)$(SysConfDir)/profile.d/bash_completion.sh \


### PR DESCRIPTION
Includes tweaks to grab releases from Github, including a new location for the ReadMeFile

I haven't extensively verified that this is the canonical new location for bash-completion; but it's up-to-date and seems to have lots of people filing issues, so it looks correctish. But someone else should probably check this before accepting this PR