### PR TITLE
p7zip + ack updates

### DIFF
--- a/Ports/ack/Makefile
+++ b/Ports/ack/Makefile
@@ -2,7 +2,7 @@ include ../../Library/Rudix.mk
 
 Title=		Ack!
 Name=		ack
-Version=	2.14
+Version=	2.20
 Site=		http://beyondgrep.com/
 Source=		http://beyondgrep.com/ack-$(Version)-single-file
 License=	Artistic License

--- a/Ports/p7zip/Makefile
+++ b/Ports/p7zip/Makefile
@@ -2,13 +2,13 @@ include ../../Library/Rudix.mk
 
 Title=		P7ZIP
 Name=		p7zip
-Version=	9.20.1
+Version=	16.02
 Site=		http://p7zip.sourceforge.net/
 Site=		http://p7zip.sourceforge.net/
 Source=		http://sourceforge.net/projects/p7zip/files/p7zip/$(Version)//$(Name)_$(Version)_src_all.tar.bz2
 License=	LGPL
 
-LicenseFile=	$(SourceDir)/DOCS/License.txt
+LicenseFile=	$(SourceDir)/DOC/License.txt
 
 UncompressedName = $(Name)_$(Version)
 
@@ -19,15 +19,17 @@ cd $(BuildDir) ; $(make) $(MakeExtra)
 endef
 
 define install_hook
+cd $(BuildDir) ; cp makefile.macosx_llvm_64bits makefile.machine
 cd $(BuildDir) ; $(make) \
 	DEST_HOME="$(PortDir)/$(InstallDir)/$(Prefix)" \
 	DEST_MAN="$(PortDir)/$(InstallDir)/$(ManDir)" $(MakeInstallExtra) install
 $(install_base_documentation)
 rm -f $(InstallDir)/$(BinDir)/*
 chmod -R u+w $(InstallDir)
-ln -s ../lib/p7zip/7z $(InstallDir)/$(BinDir)/7z
+ln -s ../lib/p7zip/7za $(InstallDir)/$(BinDir)/7z
 ln -s ../lib/p7zip/7za $(InstallDir)/$(BinDir)/7za
 ln -s ../lib/p7zip/7zr $(InstallDir)/$(BinDir)/7zr
+
 endef
 
 define test_hook


### PR DESCRIPTION
* Update p7zip to v16.02

  The 7z binary doesn't work (it complains about a missing .dll); according to docs, 7za is 7z with the dll built-in. So I've tweaked the install script to make 7z a symlink to 7za, so they're functionally equivalent.

 I'm not sure if 7zr actually works in this case. but I've left that part in place.

* Update ack to version 2.20