### PR TITLE
Undefine pre_hook function

### DIFF
--- a/Ports/libusb-compat-0.1/Makefile
+++ b/Ports/libusb-compat-0.1/Makefile
@@ -1,0 +1,15 @@
+include ../../Library/GNU.mk
+
+Title=          libusb-compat-0.1
+Name=           libusb-compat-0.1
+Version=        0.1.5
+Site=           https://github.com/hjelmn/libusb-compat-0.1
+Source=         https://github.com/hjelmn/libusb-compat-0.1/archive/v$(Version).tar.gz
+License=        LGPL
+Description=    A compatibility layer allowing applications written for libusb-0.1 to work with libusb-1.0.
+ReadMeFile=     $(SourceDir)/README
+LicenseFile=    $(SourceDir)/LICENSE
+
+define build_pre_hook
+cd $(BuildDir) && ./bootstrap.sh 
+endef

--- a/Ports/libusb/Makefile
+++ b/Ports/libusb/Makefile
@@ -2,7 +2,7 @@ include ../../Library/GNU.mk
 
 Title=		Libusb
 Name=		libusb
-Version=	1.0.9
+Version=	1.0.22
 Site=		http://www.libusb.org/
 Source=		http://downloads.sourceforge.net/libusb/$(Name)-$(Version).tar.bz2
 License=	LGPL

--- a/Ports/stm32flash/Makefile
+++ b/Ports/stm32flash/Makefile
@@ -16,6 +16,9 @@ rm -rf $(SourceDir) && git clone $(Repository) $(SourceDir)
 endef
 
 define uncompress_source
-cd $(SourceDir) && git checkout v$(Version)
+cd $(SourceDir) && git checkout v$(Version) && cd -
+endef
+
+define prep_hook
 endef
 


### PR DESCRIPTION
stm32flash: update to work on macOS 10.12
Update libusb to latest version. 
Adding libusb-compat-0.1 which is a compatiblity layer for libusb-0.1