### PR TITLE
gc: update to 7.2m

### DIFF
--- a/Ports/gc/Makefile
+++ b/Ports/gc/Makefile
@@ -2,7 +2,7 @@ include ../../Library/GNU.mk
 
 Title=		Boehm-Demers-Weiser GC
 Name=		gc
-Version=	7.2l
+Version=	7.2m
 Site=		http://hboehm.info/gc/
 Source=		https://github.com/ivmai/bdwgc/releases/download/v$(Version)/$(Name)-$(Version).tar.gz
 


### PR DESCRIPTION
* Fix comment typos in CMakeLists.txt, backgraph.c, de.c, gcconfig.h
* Fix hbp overflow in GC_install_counts
* Fix start_world not resuming all threads on Darwin
* Guard against potential buffer overflow in CORD_next and CORD_pos_fetch