### PR TITLE
Fix mv error in prep_hook

### DIFF
--- a/Ports/gputils/Makefile
+++ b/Ports/gputils/Makefile
@@ -7,7 +7,7 @@ Site=		http://gputils.sourceforge.net
 Source=		http://downloads.sourceforge.net/gputils/$(Name)-$(Version)-1.tar.gz
 License=	GPL
 
-UncompressedName=$(Name)-$(Version)-1
+UncompressedName=$(Name)-$(Version)
 
 GnuConfigureExtra += --disable-html-doc
 


### PR DESCRIPTION
Building gputils package fail with the following error:
Rudix: Info: Preparing gputils
mv: rename gputils-1.5.0-1 to gputils-build: No such file or directory
make: *** [prep] Error 1

It failed because the directory do not match with the tarball name.
The following patch fix this but, perhaps, there is a better solution.