### PR TITLE
Initial support for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,41 @@
+name: Rudix CI
+
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+    branches: [ $default-branch ]
+
+jobs:
+  build:
+    runs-on: macos-latest
+    strategy:
+      max-parallel: 5
+      fail-fast: false
+      matrix:
+        port:
+          - jsonc
+          - hello
+          - libintl
+          - lua
+          - neofetch
+          - talloc
+          - zsync
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get source and prepare to build
+        run: |
+          cd Ports/${{ matrix.port }}
+          make prep
+      - name: Build, install and create package
+        run: |
+          cd Ports/${{ matrix.port }}
+          make
+      - name: Check build from source
+        run: |
+          cd Ports/${{ matrix.port }}
+          make check
+      - name: Install and test package as admin
+        run: |
+          cd Ports/${{ matrix.port }}
+          make test


### PR DESCRIPTION
Create the initial CI by means of GitHub Actions / Workflows.

References:

* https://docs.github.com/en/actions/quickstart
* https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
* https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md
* https://github.com/actions/virtual-environments
* https://github.com/actions/starter-workflows/blob/main/ci/django.yml